### PR TITLE
-bugfix: setting customer email address when creating Stripe customer

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -169,7 +169,8 @@ module Koudoku::Subscription
   end
 
   def subscription_owner_email
-    nil
+	# returns subscription_owner.email - if object responds to :email method
+	subscription_owner.try(:email)
   end
 
   def changing_plans?


### PR DESCRIPTION
I've fixed the subscription concern to set the email address on Stripe customer object. 
This only works if subscription_owner responds to :email method
