### PR TITLE
-add: ability to set Stripe coupons when creating a subscription

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>koudoku</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>org.radrails.rails.core.railsnature</nature>
+	</natures>
+</projectDescription>

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -79,6 +79,8 @@ module Koudoku::Subscription
                   customer_attributes[:trial_end] = coupon.free_trial_ends.to_i
                 end
               end
+              
+              customer_attributes[:coupon] = @coupon_code if @coupon_code 
 
               # create a customer at that package level.
               customer = Stripe::Customer.create(customer_attributes)
@@ -155,6 +157,12 @@ module Koudoku::Subscription
         "Downgrade"
       end
     end
+  end
+  
+  # Set a Stripe coupon code that will be used when a new Stripe customer (a.k.a. Koudoku subscription)
+  # is created
+  def coupon_code=(new_code)
+    @coupon_code = new_code
   end
 
   # Pretty sure this wouldn't conflict with anything someone would put in their model

--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -115,7 +115,8 @@ module Koudoku
     def create
       @subscription = ::Subscription.new(subscription_params)
       @subscription.subscription_owner = @owner
-
+      @subscription.coupon_code = session[:koudoku_coupon_code]
+      
       if @subscription.save
         flash[:notice] = "You've been successfully upgraded."
         redirect_to owner_subscription_path(@owner, @subscription)


### PR DESCRIPTION
This allows users to use the full functionality of Stripe coupons by setting `session[:koudoku_coupon_code]` prior to creating a subscription
