### PR TITLE
passing symbol to new_registration_path to resolve #65

### DIFF
--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -62,7 +62,7 @@ module Koudoku
 
     def redirect_to_sign_up
       session["#{Koudoku.subscriptions_owned_by.to_s}_return_to"] = new_subscription_path(plan: params[:plan])
-      redirect_to new_registration_path(Koudoku.subscriptions_owned_by.to_s)
+      redirect_to new_registration_path(Koudoku.subscriptions_owned_by.to_sym)
     end
 
     def index


### PR DESCRIPTION
The Devise.mappings hash wants a symbol for the subscription_owner.
