### PR TITLE
#49 Set Stripe prorate option on subscription save

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -34,7 +34,7 @@ module Koudoku::Subscription
             prepare_for_upgrade if upgrading?
 
             # update the package level with stripe.
-            customer.update_subscription(:plan => self.plan.stripe_id)
+            customer.update_subscription(:plan => self.plan.stripe_id, :prorate => Koudoku.prorate)
 
             finalize_downgrade! if downgrading?
             finalize_upgrade! if upgrading?
@@ -86,7 +86,7 @@ module Koudoku::Subscription
               customer = Stripe::Customer.create(customer_attributes)
 
               finalize_new_customer!(customer.id, plan.price)
-              customer.update_subscription(:plan => plan.stripe_id)
+              customer.update_subscription(:plan => self.plan.stripe_id, :prorate => Koudoku.prorate)
 
             rescue Stripe::CardError => card_error
               errors[:base] << card_error.message

--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -142,7 +142,6 @@ module Koudoku
     end
 
     def update
-      #@subscription.prorate = Koudoku.prorate
       if @subscription.update_attributes(subscription_params)
         flash[:notice] = "You've successfully updated your subscription."
         redirect_to owner_subscription_path(@owner, @subscription)


### PR DESCRIPTION
Apologies for the omission - this should fix #68.

I've added the proper logic in the `processing!` method of the Koudoku::Subscription concern so that it passes the config setting for prorating in koudoku.rb.