### PR TITLE
make tests compatible with Rails 4, and explicitly specify RSpec 2

### DIFF
--- a/koudoku.gemspec
+++ b/koudoku.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "jquery-rails"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency "rspec-rails", "~> 2.14.0"
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'pry'

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -45,12 +45,6 @@ module Dummy
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = true
-
     # Enable the asset pipeline
     config.assets.enabled = true
 

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -22,16 +22,11 @@ Dummy::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
-  # Log the query plan for queries taking more than this (works
-  # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
-
   # Do not compress assets
   config.assets.compress = false
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  config.eager_load = false
 end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -64,4 +64,6 @@ Dummy::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  config.eager_load = true
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -29,9 +29,8 @@ Dummy::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  config.eager_load = false
 end


### PR DESCRIPTION
When I clone a fresh copy of the repo and try to make changes, none of the tests work because the dummy app in spec/dummy still uses a bunch of config settings which were removed in Rails 4.

Also, running the specs using RSpec 3 throws a ton of deprecation warnings. The real solution is to upgrade the spec files to use RSpec 3's syntax, but for now I opted for the quick-fix of explicitly specifying RSpec 2 in the Gemfile to make sure it runs using that version.
