### PR TITLE
Removing unnecessary "to_s"

### DIFF
--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -48,7 +48,7 @@ module Koudoku
     end
 
     def load_subscription
-      ownership_attribute = (Koudoku.subscriptions_owned_by.to_s + "_id").to_sym
+      ownership_attribute = :"#{Koudoku.subscriptions_owned_by}_id"
       @subscription = ::Subscription.where(ownership_attribute => current_owner.id).find_by_id(params[:id])
       return @subscription.present? ? @subscription : unauthorized
     end

--- a/lib/koudoku.rb
+++ b/lib/koudoku.rb
@@ -36,18 +36,16 @@ module Koudoku
   
   # e.g. :user_id
   def self.owner_id_sym
-    # e.g. :user_id
-    (Koudoku.subscriptions_owned_by.to_s + '_id').to_sym
+    :"#{Koudoku.subscriptions_owned_by}_id'"
   end
   
+  # e.g. :user=
   def self.owner_assignment_sym
-    # e.g. :user=
-    (Koudoku.subscriptions_owned_by.to_s + '=').to_sym
+    :"#{Koudoku.subscriptions_owned_by}="
   end
 
-  # e.g. Users
+  # e.g. User
   def self.owner_class
-    # e.g. User
     Koudoku.subscriptions_owned_by.to_s.classify.constantize
   end
   


### PR DESCRIPTION
`#{...}` calls `to_s` automatically under the hood - no need to explicitly include it.
