### PR TITLE
Refactoring WebhooksController and its specs

### DIFF
--- a/app/controllers/koudoku/webhooks_controller.rb
+++ b/app/controllers/koudoku/webhooks_controller.rb
@@ -6,34 +6,43 @@ module Koudoku
       raise "API key not configured. For security reasons you must configure this in 'config/koudoku.rb'." unless Koudoku.webhooks_api_key.present?
       raise "Invalid API key. Be sure the webhooks URL Stripe is configured with includes ?api_key= and the correct key." unless params[:api_key] == Koudoku.webhooks_api_key
     
-      data_json = JSON.parse request.body.read
-    
-      if data_json['type'] == "invoice.payment_succeeded"
-        
-        stripe_id = data_json['data']['object']['customer']
-        amount = data_json['data']['object']['total'].to_f / 100.0
-        subscription = ::Subscription.find_by_stripe_id(stripe_id)
+      stripe_id = data_json['data']['object']['customer']
+      subscription = ::Subscription.find_by!(stripe_id: stripe_id)
+
+      if payment_succeeded?
         subscription.payment_succeeded(amount)
-    
-      elsif data_json['type'] == "charge.failed"
-    
-        stripe_id = data_json['data']['object']['customer']
-      
-        subscription = ::Subscription.find_by_stripe_id(stripe_id)
+      elsif charge_failed?
         subscription.charge_failed
-    
-      elsif data_json['type'] == "charge.dispute.created"
-    
-        stripe_id = data_json['data']['object']['customer']
-    
-        subscription = ::Subscription.find_by_stripe_id(stripe_id)
+      elsif charge_disputed?
         subscription.charge_disputed
-      
       end
       
       render nothing: true
       
     end
+
+    private
+
+    def data_json
+      @_data_json ||= JSON.parse(request.body.read)
+    end
+
+    def payment_succeeded?
+      data_json['type'] == "invoice.payment_succeeded"
+    end
+
+    def charge_failed?
+      data_json['type'] == "charge.failed"
+    end
+
+    def charge_disputed?
+      data_json['type'] == "charge.dispute.created"
+    end
+
+    def amount
+      @_amount ||= data_json['data']['object']['total'].to_f / 100.0
+    end
+
     
   end
 end

--- a/koudoku.gemspec
+++ b/koudoku.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "jquery-rails"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency "rspec-rails", "~> 2.14.0"
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'pry'

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -45,12 +45,6 @@ module Dummy
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = true
-
     # Enable the asset pipeline
     config.assets.enabled = true
 

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -22,16 +22,11 @@ Dummy::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
-  # Log the query plan for queries taking more than this (works
-  # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
-
   # Do not compress assets
   config.assets.compress = false
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  config.eager_load = false
 end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -64,4 +64,6 @@ Dummy::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  config.eager_load = true
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -29,9 +29,8 @@ Dummy::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  config.eager_load = false
 end


### PR DESCRIPTION
In WebhooksController: decomposed the long method into some more readable smaller ones.

In webhooks_controller_specs: extracted some of the repetitive stuff to a helper method / let variables, and changed the (deprecated) `should` stuff to use RSpec's new `expect()` syntax.