### PR TITLE
Use super version of after_new_subscription_path

### DIFF
--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -165,10 +165,8 @@ module Koudoku
     end
     
     def after_new_subscription_path
-      controller = ::ApplicationController.new
-      controller.respond_to?(:after_new_subscription_path) ? 
-            controller.try(:after_new_subscription_path, @owner, @subscription) : 
-            owner_subscription_path(@owner, @subscription)
+      return super if defined?(super)
+      owner_subscription_path(@owner, @subscription)
     end
     
     def after_new_subscription_message


### PR DESCRIPTION
Attempting to fetch the url from a `after_new_subscription_path` in a new instance of `ApplicationController` throws `undefined method host for nil:NilClass` as there is no request for the controller instance to fetch a host from.

Working up the object tree means it can properly return a working path.