### PR TITLE
Putting in version check for Rails 4 compatibility

### DIFF
--- a/lib/generators/koudoku/templates/app/models/plan.rb
+++ b/lib/generators/koudoku/templates/app/models/plan.rb
@@ -2,5 +2,5 @@ class Plan < ActiveRecord::Base
   has_many :subscriptions
 
   include Koudoku::Plan
-  attr_accessible :display_order, :features, :highlight, :interval, :name, :price, :stripe_id
+  <%= "attr_accessible :display_order, :features, :highlight, :interval, :name, :price, :stripe_id" if Rails::VERSION::MAJOR == 3 %>
 end


### PR DESCRIPTION
Putting in a version check for Rails 4 compatibility. Rails 4 doesn't use attr_accessible.
This exact check already existed in /lib/generators/koudoku/templates/app/models/subscription.rb.