### PR TITLE
Added stripe api version to the initializer

### DIFF
--- a/lib/generators/koudoku/templates/config/initializers/koudoku.rb
+++ b/lib/generators/koudoku/templates/config/initializers/koudoku.rb
@@ -2,6 +2,8 @@ Koudoku.setup do |config|
   config.subscriptions_owned_by = :<%= subscription_owner_model %>
   config.stripe_publishable_key = ENV['STRIPE_PUBLISHABLE_KEY']
   config.stripe_secret_key = ENV['STRIPE_SECRET_KEY']
+  
+  Stripe.api_version = '2015-01-11' #Making sure the API version used is compatible.
   # config.prorate = false # Default is true, set to false to disable prorating subscriptions
   # config.free_trial_length = 30
   


### PR DESCRIPTION
On 2015-02-18 stripe had a major update to the api. In order for koudoku to work, the newsest api version that we can use is 2015-02-16.