### PR TITLE
raise error if credit_card_token is missing

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -67,6 +67,7 @@ module Koudoku::Subscription
 
             begin
 
+              raise Koudoku::NilCardToken, "Possible javascript error" if credit_card_token.empty?
               customer_attributes = {
                 description: subscription_owner_description,
                 email: subscription_owner_email,
@@ -79,8 +80,8 @@ module Koudoku::Subscription
                   customer_attributes[:trial_end] = coupon.free_trial_ends.to_i
                 end
               end
-              
-              customer_attributes[:coupon] = @coupon_code if @coupon_code 
+
+              customer_attributes[:coupon] = @coupon_code if @coupon_code
 
               # create a customer at that package level.
               customer = Stripe::Customer.create(customer_attributes)
@@ -135,8 +136,8 @@ module Koudoku::Subscription
     end
 
   end
-  
-  
+
+
   def describe_difference(plan_to_describe)
     if plan.nil?
       if persisted?
@@ -156,7 +157,7 @@ module Koudoku::Subscription
       end
     end
   end
-  
+
   # Set a Stripe coupon code that will be used when a new Stripe customer (a.k.a. Koudoku subscription)
   # is created
   def coupon_code=(new_code)

--- a/lib/koudoku/errors.rb
+++ b/lib/koudoku/errors.rb
@@ -1,0 +1,4 @@
+module Koudoku
+  class Error < StandardError; end
+  class NilCardToken < Error; end
+end


### PR DESCRIPTION
Fixes #136.

If a javascript error occurs and no credit card token is generated, a subscriber is still created in stripe. An opaque error message about no default cards then occurs later on. An error should be raised instead of attempting to continue with the subscription.