### PR TITLE
Hotfix: hotfix: Don't load the plans two times in Subscription#index

### DIFF
--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -6,7 +6,7 @@ module Koudoku
     before_filter :load_plans, only: [:index, :edit]
 
     def load_plans
-      @plans = ::Plan.order(:price)
+      @plans = ::Plan.order(:display_order)
     end
 
     def unauthorized
@@ -74,9 +74,6 @@ module Koudoku
         redirect_to koudoku.edit_owner_subscription_path(current_owner, current_owner.subscription)
       end
 
-      # Load all plans.
-      @plans = ::Plan.order(:display_order).all
-      
       # Don't prep a subscription unless a user is authenticated.
       unless no_owner?
         # we should also set the owner of the subscription here.


### PR DESCRIPTION
Hi,

I wanted to overwrite load_plans in my SubscriptionController and I was quite surprised to see that not working when I looked at the plans in Subscription#Index.
It looks like @plans is setted again so it's impossible to overwrite load_plans.
This PR fixes this.