### PR TITLE
Feature/coupons

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,23 +136,19 @@ Or, if you've replaced your `application.css` with an `application.scss` (like I
 ``` 
    
 ## Using Coupons
-
-While more robust coupon support is expected in the future, the simple way to use a coupon is to first create it:
+Coupons mirror the functionality of Stripe coupons https://stripe.com/docs/api#coupons, creating a coupon subsequently adds that coupon to your Stripe account. 
 
 ```ruby
-    coupon = Coupon.create(code: '30-days-free', free_trial_length: 30)
+    coupon = Coupon.create(code: '10percentoff', duration: 'repeating', percent_off: 10)
 ```   
    
-Then assign it to a _new_ subscription before saving:
-
+And can then be assigned to a new subscription by setting a session variable.
 ```ruby
-    subscription = Subscription.new(...)
-    subscription.coupon = coupon
-    subscription.save
+    session[:koudoku_coupon_code] = '10percentoff'
 ```    
+*Note:*
+Destroying a coupon locally will delete that coupon from Stripe and Stripe doesn't support updating coupons after they've been created. 
 
-It should be noted that these coupons are different from the coupons provided natively by Stripe.
-    
 ## Implementing Logging, Notifications, etc.
 
 The included module defines the following empty "template methods" which you're able to provide an implementation for in `Subscription`:

--- a/app/concerns/koudoku/coupon.rb
+++ b/app/concerns/koudoku/coupon.rb
@@ -1,0 +1,39 @@
+module Koudoku::Coupon
+  extend ActiveSupport::Concern
+
+  included do
+    VALID_DURATIONS = %['repeating', 'once', 'forever']
+
+    # Validations
+    validates_presence_of :duration, :code
+    validates_uniqueness_of :code
+    validate :exclusivity_of_percentage_and_amount_off
+    validate :presence_of_atleast_percentage_or_amount_off
+    validate :duration_in_months_is_relative_to_duration
+    validate :stripe_valid_duration
+
+    private
+
+    def duration_in_months_is_relative_to_duration
+      if duration != 'repeating' && duration_in_months.present?
+        errors.add(:duration_in_months, 'can only be set when duration is :repeating')
+      end
+    end
+
+    def exclusivity_of_percentage_and_amount_off
+      if percentage_off.present? && amount_off.present?
+        errors.add(:percentage_off, 'cannot set both amount_off and percentage_off')
+      end
+    end
+
+    def presence_of_atleast_percentage_or_amount_off
+      if percentage_off.blank? && amount_off.blank?
+        errors.add(:percentage_off, 'need to set atleast one off attribute')
+      end
+    end
+
+    def stripe_valid_duration
+      errors.add(:duration, "is not valid. Valid durations include #{VALID_DURATIONS.join(',')}") unless VALID_DURATIONS.include? duration
+    end
+  end
+end

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -75,12 +75,10 @@ module Koudoku::Subscription
 
               # If the class we're being included in supports coupons ..
               if respond_to? :coupon
-                if coupon.present? and coupon.free_trial?
-                  customer_attributes[:trial_end] = coupon.free_trial_ends.to_i
+                if coupon.present?
+                  customer_attributes[:coupon] = coupon.code
                 end
               end
-              
-              customer_attributes[:coupon] = @coupon_code if @coupon_code 
 
               # create a customer at that package level.
               customer = Stripe::Customer.create(customer_attributes)
@@ -159,7 +157,7 @@ module Koudoku::Subscription
   # Set a Stripe coupon code that will be used when a new Stripe customer (a.k.a. Koudoku subscription)
   # is created
   def coupon_code=(new_code)
-    @coupon_code = new_code
+    coupon = Coupon.find_by_code(new_code)
   end
 
   # Pretty sure this wouldn't conflict with anything someone would put in their model

--- a/lib/generators/koudoku/install_generator.rb
+++ b/lib/generators/koudoku/install_generator.rb
@@ -43,7 +43,7 @@ module Koudoku
       template "app/models/plan.rb"
 
       # Add coupons.
-      generate("model coupon code:string free_trial_length:string")
+      generate("model coupon code:string interval:integer amount_off:float percent_off:integer redeem_by:datetime max_redemptions:integer duration:integer duration_in_months:integer")
       template "app/models/coupon.rb"
 
       # Update the owner relationship.

--- a/lib/generators/koudoku/install_generator.rb
+++ b/lib/generators/koudoku/install_generator.rb
@@ -43,7 +43,7 @@ module Koudoku
       template "app/models/plan.rb"
 
       # Add coupons.
-      generate("model coupon code:string interval:integer amount_off:float percent_off:integer redeem_by:datetime max_redemptions:integer duration:integer duration_in_months:integer")
+      generate("model coupon code:string interval:integer amount_off:float percent_off:integer redeem_by:datetime max_redemptions:integer duration:string duration_in_months:integer")
       template "app/models/coupon.rb"
 
       # Update the owner relationship.

--- a/lib/generators/koudoku/templates/app/models/coupon.rb
+++ b/lib/generators/koudoku/templates/app/models/coupon.rb
@@ -1,5 +1,6 @@
 class Coupon < ActiveRecord::Base
-  
+  include Koudoku::Coupon
+
   has_many :subscriptions
 
 end

--- a/spec/concerns/koudoku/coupon_spec.rb
+++ b/spec/concerns/koudoku/coupon_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Koudoku::Coupon do
+  describe "validations" do
+    before :each do
+      @coupon = Coupon.new(duration: 'once', code: 'code', percentage_off: 10)
+    end
+
+    it "invalid if amount_off and percentage_off set at the sametime" do
+      @coupon.amount_off = 1.99
+      @coupon.percentage_off = 50
+
+      expect(@coupon).to_not be_valid
+    end
+
+    it "valid if only percentage_off is set" do
+      @coupon.amount_off = nil
+      @coupon.percentage_off = 50
+
+      expect(@coupon).to be_valid
+    end
+
+    it "valid if only amount_off is set" do
+      @coupon.amount_off = 1.99
+      @coupon.percentage_off = nil
+
+      expect(@coupon).to be_valid
+    end
+
+    it "invalid if neither amount_off or percentage_off is set" do
+      @coupon.amount_off = nil
+      @coupon.percentage_off = nil
+
+      expect(@coupon).to_not be_valid
+    end
+
+    it "valid if duration_in_months is set when duration is repeating " do
+      @coupon.duration = 'repeating'
+      @coupon.duration_in_months = 2
+      expect(@coupon).to be_valid
+    end
+
+    it "invalid if duration_in_months is set when duration not repeating" do
+      @coupon.duration = 'once'
+      @coupon.duration_in_months = 2
+
+      expect(@coupon).to_not be_valid
+    end
+  end
+end

--- a/spec/dummy/app/models/coupon.rb
+++ b/spec/dummy/app/models/coupon.rb
@@ -1,3 +1,6 @@
 class Coupon < ActiveRecord::Base
-  
+  include Koudoku::Coupon
+
+  has_many :subscriptions
+
 end

--- a/spec/dummy/app/models/subscription.rb
+++ b/spec/dummy/app/models/subscription.rb
@@ -1,6 +1,7 @@
 class Subscription < ActiveRecord::Base
   include Koudoku::Subscription
 
+  
   belongs_to :customer
   belongs_to :coupon
 

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  mount Koudoku::Engine, at: "koudoku"
+
+  # Added by Koudoku.
+  mount Koudoku::Engine, at: 'koudoku'
   scope module: 'koudoku' do
     get 'pricing' => 'subscriptions#index', as: 'pricing'
   end

--- a/spec/dummy/db/migrate/20130318204502_create_coupons.rb
+++ b/spec/dummy/db/migrate/20130318204502_create_coupons.rb
@@ -3,6 +3,13 @@ class CreateCoupons < ActiveRecord::Migration
     create_table :coupons do |t|
       t.string :code
       t.string :free_trial_length
+      t.integer :coupons, :interval, :integer
+      t.float :coupons, :amount_off, :float
+      t.integer :coupons, :percentage_off, :integer
+      t.datetime :coupons, :redeem_by, :datetime
+      t.integer :coupons, :max_redemptions, :integer
+      t.integer :coupons, :duration, :integer
+      t.integer :coupons, :duration_in_months, :integer
 
       t.timestamps
     end

--- a/spec/dummy/db/migrate/20130318204502_create_coupons.rb
+++ b/spec/dummy/db/migrate/20130318204502_create_coupons.rb
@@ -3,13 +3,13 @@ class CreateCoupons < ActiveRecord::Migration
     create_table :coupons do |t|
       t.string :code
       t.string :free_trial_length
-      t.integer :coupons, :interval, :integer
-      t.float :coupons, :amount_off, :float
-      t.integer :coupons, :percentage_off, :integer
-      t.datetime :coupons, :redeem_by, :datetime
-      t.integer :coupons, :max_redemptions, :integer
-      t.integer :coupons, :duration, :integer
-      t.integer :coupons, :duration_in_months, :integer
+      t.integer :coupons, :interval
+      t.float :coupons, :amount_off
+      t.integer :coupons, :percentage_off
+      t.datetime :coupons, :redeem_by
+      t.integer :coupons, :max_redemptions
+      t.string :coupons, :duration
+      t.integer :coupons, :duration_in_months
 
       t.timestamps
     end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -9,36 +9,44 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130520163946) do
+ActiveRecord::Schema.define(version: 20130520163946) do
 
-  create_table "coupons", :force => true do |t|
+  create_table "coupons", force: true do |t|
     t.string   "code"
     t.string   "free_trial_length"
-    t.datetime "created_at",        :null => false
-    t.datetime "updated_at",        :null => false
+    t.integer  "coupons"
+    t.integer  "interval"
+    t.float    "amount_off"
+    t.integer  "percentage_off"
+    t.datetime "redeem_by"
+    t.integer  "max_redemptions"
+    t.string   "duration"
+    t.integer  "duration_in_months"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "customers", :force => true do |t|
+  create_table "customers", force: true do |t|
     t.string   "email"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  create_table "plans", :force => true do |t|
+  create_table "plans", force: true do |t|
     t.string   "name"
     t.string   "stripe_id"
     t.float    "price"
     t.text     "features"
     t.boolean  "highlight"
     t.integer  "display_order"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "interval"
   end
 
-  create_table "subscriptions", :force => true do |t|
+  create_table "subscriptions", force: true do |t|
     t.string   "stripe_id"
     t.integer  "plan_id"
     t.string   "last_four"
@@ -46,8 +54,8 @@ ActiveRecord::Schema.define(:version => 20130520163946) do
     t.string   "card_type"
     t.float    "current_price"
     t.integer  "customer_id"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end


### PR DESCRIPTION
My attempt at adding native support for Stripe coupons. 

Creating a coupon locally will mirror the same coupon data on your Stripe dashboard. Assigning coupons is done from the subscription `:create` action by setting the `:koudoku_coupon_code` session. 