### PR TITLE
Add koudoku helpers to application helper (Issue 121)

### DIFF
--- a/lib/generators/koudoku/install_generator.rb
+++ b/lib/generators/koudoku/install_generator.rb
@@ -54,7 +54,8 @@ module Koudoku
       copy_file "app/views/koudoku/subscriptions/_social_proof.html.erb"
 
       # Enable Koudoku helpers
-      inject_into_class "app/helpers/application_helper.rb", "include Koudoku::ApplicationHelper"
+      inject_into_class "app/helpers/application_helper.rb", ApplicationHelper,
+                        "include Koudoku::ApplicationHelper\n\n"
 
       # Add webhooks to the route.
 

--- a/lib/generators/koudoku/install_generator.rb
+++ b/lib/generators/koudoku/install_generator.rb
@@ -55,7 +55,7 @@ module Koudoku
 
       # Enable Koudoku helpers
       inject_into_class "app/helpers/application_helper.rb", ApplicationHelper,
-                        "include Koudoku::ApplicationHelper\n\n"
+                        "# Added by Koudoku.\n include Koudoku::ApplicationHelper\n\n"
 
       # Add webhooks to the route.
 

--- a/lib/generators/koudoku/install_generator.rb
+++ b/lib/generators/koudoku/install_generator.rb
@@ -53,6 +53,9 @@ module Koudoku
       # Install the pricing table.
       copy_file "app/views/koudoku/subscriptions/_social_proof.html.erb"
 
+      # Enable Koudoku helpers
+      inject_into_class "app/helpers/application_helper.rb", "include Koudoku::ApplicationHelper"
+
       # Add webhooks to the route.
 
       route <<-RUBY


### PR DESCRIPTION
Hi there! 
Was having the [issue #121 of inaccessible helpers](https://github.com/andrewculver/koudoku/issues/121) in both Rails 4.2 and 5.0.2, and had to add 'include Koudoku::ApplicationHelper' manually. So, in this pull request, it ought to write that into ApplicationHelper on install. 
Thanks!