### PR TITLE
Don't expload if a subscription doesn't exist when being hit from Stripe webhook

### DIFF
--- a/config/initializers/stripe_event.rb
+++ b/config/initializers/stripe_event.rb
@@ -2,26 +2,43 @@ StripeEvent.configure do |events|
   events.subscribe 'charge.failed' do |event|
     stripe_id = event.data.object['customer']
       
-    subscription = ::Subscription.find_by_stripe_id(stripe_id)
-    subscription.charge_failed
+    subscription = ::Subscription.find_by(stripe_id: stripe_id)
+    if subscription.present?
+      subscription.charge_failed
+    else
+      Rails.logger.warn "Received webhook call for stripe charge.failed event but subscription does not exist for stripe ID #{stripe_id}"
+    end
   end
   
   events.subscribe 'invoice.payment_succeeded' do |event|
     stripe_id = event.data.object['customer']
     amount = event.data.object['total'].to_f / 100.0
-    subscription = ::Subscription.find_by_stripe_id(stripe_id)
-    subscription.payment_succeeded(amount)
+    subscription = ::Subscription.find_by(stripe_id: stripe_id)
+    if subscription.present?
+      subscription.payment_succeeded(amount)
+    else
+      Rails.logger.warn "Received webhook call for stripe invoice.payment_succeeded event but subscription does not exist for stripe ID #{stripe_id}"
+    end
   end
   
   events.subscribe 'charge.dispute.created' do |event|
     stripe_id = event.data.object['customer']
-    subscription = ::Subscription.find_by_stripe_id(stripe_id)
-    subscription.charge_disputed
+    subscription = ::Subscription.find_by(stripe_id: stripe_id)
+    if subscription.present?
+      subscription.charge_disputed
+    else
+      Rails.logger.warn "Received webhook call for stripe charge.dispute.created event but subscription does not exist for stripe ID #{stripe_id}"
+    end
   end
   
   events.subscribe 'customer.subscription.deleted' do |event|
     stripe_id = event.data.object['customer']
-    subscription = ::Subscription.find_by_stripe_id(stripe_id)
-    subscription.subscription_owner.try(:cancel)
+    subscription = ::Subscription.find_by(stripe_id: stripe_id)
+
+    if subscription.present?
+      subscription.subscription_owner.try(:cancel)
+    else
+      Rails.logger.warn "Received webhook call for stripe customer.subscription.deleted event but subscription does not exist for stripe ID #{stripe_id}"
+    end
   end
 end


### PR DESCRIPTION
# The Problem
If you use your Stripe account for other things other than the stuff you are linking to Koudoku then Stripe still hits the Koudoku webhooks with events from the other stuff. The result is that the `stripe_id` that hits the Koudoku registered webhooks throws a 500 error to Stripe.

Now that would be fine, and maybe even a good thing, HOWEVER **Stripe will keep retrying to hit the webhook until it gets a 200 response**. Eventually Stripe will threaten to even kill your webhook.

# The Solution
Instead of letting it throw errors like `NoMethodError: undefined method `payment_succeeded' for nil:NilClass`, just log a warning if the subscription doesn't exist for the `stripe_id` that was posted.

# Also...
Using dynamic `find_by's like `find_by_bleh` is deprecated in Rails 4 and you should use `find_by(stripe_id: strip_id)` instead, so I updated these lines. See http://edgeguides.rubyonrails.org/4_0_release_notes.html#active-record-deprecations for reference.

Great gem BTW! Very useful!!