### PR TITLE
Persist stripe subscription ID on Subscription

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -113,7 +113,7 @@ module Koudoku::Subscription
                 end
               end
 
-              Stripe::Subscription.create(subscription_attributes)
+              subscription = Stripe::Subscription.create(subscription_attributes)
 
             rescue Stripe::CardError => card_error
               errors[:base] << card_error.message
@@ -124,6 +124,10 @@ module Koudoku::Subscription
             # store the customer id.
             self.stripe_id = customer.id
             self.last_four = customer.sources.retrieve(customer.default_source).last4
+
+            if respond_to? :stripe_subscription_id
+              self.stripe_subscription_id = subscription.id
+            end
 
             finalize_new_subscription!
             finalize_upgrade!

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -129,6 +129,10 @@ module Koudoku::Subscription
               self.stripe_subscription_id = subscription.id
             end
 
+            if subscription_owner.respond_to? :stripe_id
+              subscription_owner.update(stripe_id: customer.id)
+            end
+
             finalize_new_subscription!
             finalize_upgrade!
 


### PR DESCRIPTION
Also clones stripe customer ID to subscription owner (Team), too. This keeps backwards compatibility by naming the attribute `Subscription#stripe_subscription_id` rather than repurposing `Subscription#stripe_id` (which is really the stripe customer ID).

I didn't see any tests for this concern so please advise if there's a preferred test approach.