### PR TITLE
Improvements and updates from Bullet Train

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -71,7 +71,8 @@ module Koudoku::Subscription
               customer_attributes = {
                 description: subscription_owner_description,
                 email: subscription_owner_email,
-                card: credit_card_token # obtained with Stripe.js
+                card: credit_card_token, # obtained with Stripe.js
+                metadata: subscription_owner_metadata
               }
 
               # If the class we're being included in supports coupons ..
@@ -182,6 +183,10 @@ module Koudoku::Subscription
 
   def subscription_owner_email
     "#{subscription_owner.try(:formatted_email_address) || subscription_owner.try(:email)}"
+  end
+
+  def subscription_owner_metadata
+    subscription_owner.try(:stripe_metadata)
   end
 
   def changing_plans?

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -103,7 +103,8 @@ module Koudoku::Subscription
                     plan: self.plan.stripe_id,
                     quantity: subscription_owner_quantity
                   }
-                ]
+                ],
+                trial_from_plan: true
               }
 
               # If the class we're being included in supports Link Mink ..

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -78,7 +78,7 @@ module Koudoku::Subscription
               # If the class we're being included in supports Link Mink ..
               if respond_to? :link_mink_id
                 if link_mink_id.present?
-                  customer_attributes[:customer_attributes][:identifier] = link_mink_id
+                  customer_attributes[:metadata][:identifier] = link_mink_id
                 end
               end
 

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -98,7 +98,7 @@ module Koudoku::Subscription
               # If the class we're being included in supports Link Mink ..
               if respond_to? :link_mink_id
                 if link_mink_id.present?
-                  subscription_attributes[:metadata][:identifier] = link_mink_id
+                  subscription_attributes[:metadata] = {identifier: link_mink_id}
                 end
               end
 

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -67,11 +67,12 @@ module Koudoku::Subscription
 
             begin
               raise Koudoku::NilCardToken, "No card token received. Check for JavaScript errors breaking Stripe.js on the previous page." unless credit_card_token.present?
+
               customer_attributes = {
                 description: subscription_owner_description,
                 email: subscription_owner_email,
                 card: credit_card_token # obtained with Stripe.js
-              }
+              }.merge(try(:custom_stripe_attributes) || {})
 
               # If the class we're being included in supports coupons ..
               if respond_to? :coupon

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -98,7 +98,7 @@ module Koudoku::Subscription
               # If the class we're being included in supports Link Mink ..
               if respond_to? :link_mink_id
                 if link_mink_id.present?
-                  subscription_attributes[:metadata] = {identifier: link_mink_id}
+                  subscription_attributes[:metadata] = {identifier: link_mink_id, testing: '123'}
                 end
               end
 

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -75,6 +75,13 @@ module Koudoku::Subscription
                 metadata: subscription_owner_metadata
               }
 
+              # If the class we're being included in supports Rewardful ..
+              if respond_to? :rewardful_id
+                if rewardful_id.present?
+                  customer_attributes[:metadata] = {referral: rewardful_id}
+                end
+              end
+
               # If the class we're being included in supports coupons ..
               if respond_to? :coupon
                 if coupon.present? and coupon.free_trial?

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -102,7 +102,7 @@ module Koudoku::Subscription
               # If the class we're being included in supports Link Mink ..
               if respond_to? :link_mink_id
                 if link_mink_id.present?
-                  subscription_attributes[:metadata] = {identifier: link_mink_id, testing: '123'}
+                  subscription_attributes[:metadata] = {identifier: link_mink_id}
                 end
               end
 

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -90,9 +90,13 @@ module Koudoku::Subscription
               finalize_new_customer!(customer.id, plan.price)
 
               subscription_attributes = {
-                plan: self.plan.stripe_id,
-                prorate: Koudoku.prorate,
-                quantity: subscription_owner_quantity,
+                customer: customer.id,
+                items:[
+                  {
+                    plan: self.plan.stripe_id,
+                    quantity: subscription_owner_quantity
+                  }
+                ]
               }
 
               # If the class we're being included in supports Link Mink ..
@@ -102,7 +106,7 @@ module Koudoku::Subscription
                 end
               end
 
-              customer.update_subscription(subscription_attributes)
+              Stripe::Subscription.create(subscription_attributes)
 
             rescue Stripe::CardError => card_error
               errors[:base] << card_error.message

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -72,7 +72,7 @@ module Koudoku::Subscription
                 description: subscription_owner_description,
                 email: subscription_owner_email,
                 card: credit_card_token # obtained with Stripe.js
-              }.merge(try(:custom_stripe_attributes) || {})
+              }
 
               # If the class we're being included in supports coupons ..
               if respond_to? :coupon
@@ -177,11 +177,11 @@ module Koudoku::Subscription
   def subscription_owner_description
     # assuming owner responds to name.
     # we should check for whether it responds to this or not.
-    "#{subscription_owner.try(:name) || subscription_owner.try(:id)}"
+    "#{subscription_owner.try(:billing_name) || subscription_owner.try(:name) || subscription_owner.try(:id)}"
   end
 
   def subscription_owner_email
-    "#{subscription_owner.try(:email)}"
+    "#{subscription_owner.try(:formatted_email_address) || subscription_owner.try(:email)}"
   end
 
   def changing_plans?

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -92,7 +92,7 @@ module Koudoku::Subscription
             rescue Stripe::CardError => card_error
               errors[:base] << card_error.message
               card_was_declined
-              return false
+              throw :abort
             end
 
             # store the customer id.

--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -152,12 +152,17 @@ module Koudoku
     end
 
     def update
-      if @subscription.update_attributes(subscription_params)
-        flash[:notice] = I18n.t('koudoku.confirmations.subscription_updated')
-        redirect_to owner_subscription_path(@owner, @subscription)
-      else
-        flash[:error] = I18n.t('koudoku.failure.problem_processing_transaction')
-        render :edit
+      begin
+        if @subscription.update_attributes(subscription_params)
+          flash[:notice] = I18n.t('koudoku.confirmations.subscription_updated')
+          redirect_to owner_subscription_path(@owner, @subscription)
+        else
+          flash[:error] = I18n.t('koudoku.failure.problem_processing_transaction')
+          render :edit
+        end
+      rescue Exception => e
+        flash[:error] = I18n.t('koudoku.failure.plan_change_needs_updated_card', :error => e.message)
+        redirect_to edit_owner_subscription_path(@owner, @subscription, update: 'card')
       end
     end
 

--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -133,7 +133,11 @@ module Koudoku
         flash[:notice] = after_new_subscription_message
         redirect_to after_new_subscription_path
       else
-        flash[:error] = I18n.t('koudoku.failure.problem_processing_transaction')
+
+        ## commenting this out because the model callbacks are actually
+        ## providing the error message we need here from stripe.
+        # flash[:error] = I18n.t('koudoku.failure.problem_processing_transaction')
+
         render :new
       end
     end

--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -175,7 +175,7 @@ module Koudoku
 
       # If strong_parameters is around, use that.
       if defined?(ActionController::StrongParameters)
-        params.require(:subscription).permit(:plan_id, :stripe_id, :current_price, :credit_card_token, :card_type, :last_four)
+        params.require(:subscription).permit(:plan_id, :stripe_id, :current_price, :credit_card_token, :card_type, :last_four, :link_mink_id)
       else
         # Otherwise, let's hope they're using attr_accessible to protect their models!
         params[:subscription]

--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -125,7 +125,10 @@ module Koudoku
 
     def create
 
-      @subscription = ::Subscription.new(subscription_params)
+      all_subscription_params = subscription_params.to_hash
+      all_subscription_params[:rewardful_id] = params[:referral] if params[:referral]
+
+      @subscription = ::Subscription.new(all_subscription_params)
       @subscription.subscription_owner = @owner
       @subscription.coupon_code = session[:koudoku_coupon_code]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
       subscription_upgraded: "You've been successfully upgraded."
     failure:
       problem_processing_transaction: "There was a problem processing this transaction."
+      plan_change_needs_updated_card: "Our payment provider returned the following message: \"%{error}\" Please update your payment information before trying to change plans."
       unauthorized: "Unauthorized"
     plan_intervals:
       month: "month"


### PR DESCRIPTION
People frequently ask whether Koudoku is still maintained because `master` hasn't received much attention for a long time. Many people _are_ still actively using Koudoku, but most of my personal efforts with development on it are now limited to keeping it working well in the context of [Bullet Train](https://bullettrain.co/) specifically. This work is much easier for me and much less time consuming because I control so much more of the context of the apps that are built on top of Bullet Train (e.g. Rails version, Devise, CanCanCan, Bootstrap, UI, etc.) It also doesn't hurt that I'm compensated financially by folks who run into issues or need new features (e.g. the support we recently added for Rewardful and Link Mink affiliate programs.)

I've kept many of these updates in a separate branch until now. In the short term, this PR can help people understand which things have changed in the `bullet-train` branch of Koudoku. It's possible that using this branch will help Koudoku work better in modern Rails apps, but I can't be sure because the only modern Rails apps I work on anymore are Bullet Train-based.

The only thing not included in this branch are lots of modifications and customizations made to the `.html.erb` views. All of those are specific to Bullet Train's UI CSS and are only contained in the private Bullet Train repo. I have no idea off the top of my head what state the views in this repository are in, or which version of Bootstrap they use, etc. If someone wants to provide fixing updates for the latest version of Bootstrap, please send a PR!