### PR TITLE
DEPRECATION WARNING: update_attributes

### DIFF
--- a/app/controllers/koudoku/subscriptions_controller.rb
+++ b/app/controllers/koudoku/subscriptions_controller.rb
@@ -152,7 +152,7 @@ module Koudoku
     end
 
     def update
-      if @subscription.update_attributes(subscription_params)
+      if @subscription.update(subscription_params)
         flash[:notice] = I18n.t('koudoku.confirmations.subscription_updated')
         redirect_to owner_subscription_path(@owner, @subscription)
       else


### PR DESCRIPTION
## Fix

```
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead) (called from update at /Users/user/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/bundler/gems/koudoku/app/controllers/koudoku/subscriptions_controller.rb:163)
```